### PR TITLE
self-comparison always evaluates to true

### DIFF
--- a/include/libach_private.h
+++ b/include/libach_private.h
@@ -100,7 +100,7 @@ ts_sub(struct timespec t1, struct timespec t0)
     /* bound at zero */
     if (t0.tv_sec > t1.tv_sec)
         return delta;
-    if (t0.tv_sec == t0.tv_sec &&
+    if (t0.tv_sec == t1.tv_sec &&
         t0.tv_nsec > t1.tv_nsec)
         return delta;
 


### PR DESCRIPTION
I noticed this warning scrolling by. it's an actual bug with a real probability of getting hit.

some `-Wformat=` warnings are in the build output as well but those aren't as important.