### PR TITLE
ach_create_len was used, but same calculation overwrites result

### DIFF
--- a/src/klinux/ach_klinux.c
+++ b/src/klinux/ach_klinux.c
@@ -232,10 +232,6 @@ static struct ach_header *ach_create(const char *name, size_t frame_cnt, size_t 
 	struct ach_header *shm;
 	int len = ach_create_len(frame_cnt, frame_size);
 
-	len = sizeof(struct ach_header) +
-	    frame_cnt * sizeof(ach_index_t) +
-	    frame_cnt * frame_size + 3 * sizeof(uint64_t);
-
 	shm = (struct ach_header *)kzalloc(len, GFP_KERNEL);
 	if (unlikely(!shm)) {
 		printk(KERN_ERR "ach: Unable to allocate buffer memory\n");


### PR DESCRIPTION
ref: [`ach_create_len()`](https://github.com/golems/ach/blob/c34a775190307a59db42b044b145dc23ced633e2/include/ach/impl_generic.h#L133)

didn't cause a bug but might have if anyone touched that function.