### PR TITLE
Fix bug when queue size == 1

### DIFF
--- a/src/libach_posix.c
+++ b/src/libach_posix.c
@@ -626,7 +626,7 @@ libach_open_posix( ach_channel_t *chan, const char *channel_name,
         chan->len = len;
         chan->shm = shm;
         chan->seq_num = 0;
-        chan->next_index = 1;
+        chan->next_index = 0;
         chan->cancel = 0;
         chan->clock = clock;
     }


### PR DESCRIPTION
The initial values for a channel caused the first read to already be past the end of the queue (when the queue size is 1). This was fixed by simply changing the initial value of next_index to 0. If there is a better fix, please let me know.